### PR TITLE
Update to hashbrown 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 priority-queue = "0.6.0"
 rustc-hash = "1.1.0"
-hashbrown = "0.8.0"
+hashbrown = "0.9.0"
 clap = { version = "2.33.1", optional = true }
 
 [features]

--- a/src/watch_list.rs
+++ b/src/watch_list.rs
@@ -69,7 +69,7 @@ impl WatchList {
       debug_assert_ne!(l_0, l_1);
       if l_1.assn(assns) == Some(true) {
         debug_assert_eq!(&occs[l_1.raw() as usize][&cref], &l_0);
-        return true;
+        return false;
       }
       let mut next = None;
       for &l in cref.iter(db).filter(|&&l| l != l_1) {
@@ -91,11 +91,11 @@ impl WatchList {
         debug_assert_eq!(occs[next.raw() as usize][&cref], l_1);
         debug_assert_eq!(occs[l_1.raw() as usize][&cref], next);
         debug_assert!(next.assn(assns) != Some(false));
-        false
+        true
       } else {
         debug_assert_eq!(occs[l_1.raw() as usize][&cref], l_0);
         cb(cref, l_1);
-        true
+        false
       }
     });
     for _ in out {}


### PR DESCRIPTION
The behavior of `drain_filter` has changed in this release:

https://github.com/rust-lang/hashbrown/issues/186